### PR TITLE
fixed a bug that caused vcf_parser to break when using VCFs w/o FORMAT 

### DIFF
--- a/examples/exac_head.vcf
+++ b/examples/exac_head.vcf
@@ -1,0 +1,202 @@
+##fileformat=VCFv4.1
+##ALT=<ID=NON_REF,Description="Represents any possible alternative allele at this location">
+##FILTER=<ID=InbreedingCoeff_Filter,Description="InbreedingCoeff <= -0.2">
+##FILTER=<ID=AC_Adj0_Filter,Description="AC_Adj == 0">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=NewCut_Filter,Description="VQSLOD > -2.632 && InbreedingCoeff >-0.8">
+##FILTER=<ID=VQSRTrancheINDEL95.00to96.00,Description="Truth sensitivity tranche level for INDEL model at VQS Lod: 0.9503 <= x < 1.2168">
+##FILTER=<ID=VQSRTrancheINDEL96.00to97.00,Description="Truth sensitivity tranche level for INDEL model at VQS Lod: 0.7622 <= x < 0.9503">
+##FILTER=<ID=VQSRTrancheINDEL97.00to99.00,Description="Truth sensitivity tranche level for INDEL model at VQS Lod: 0.0426 <= x < 0.7622">
+##FILTER=<ID=VQSRTrancheINDEL99.00to99.50,Description="Truth sensitivity tranche level for INDEL model at VQS Lod: -0.8363 <= x < 0.0426">
+##FILTER=<ID=VQSRTrancheINDEL99.50to99.90,Description="Truth sensitivity tranche level for INDEL model at VQS Lod: -8.5421 <= x < -0.8363">
+##FILTER=<ID=VQSRTrancheINDEL99.90to99.95,Description="Truth sensitivity tranche level for INDEL model at VQS Lod: -18.4482 <= x < -8.5421">
+##FILTER=<ID=VQSRTrancheINDEL99.95to100.00+,Description="Truth sensitivity tranche level for INDEL model at VQS Lod < -37254.4742">
+##FILTER=<ID=VQSRTrancheINDEL99.95to100.00,Description="Truth sensitivity tranche level for INDEL model at VQS Lod: -37254.4742 <= x < -18.4482">
+##FILTER=<ID=VQSRTrancheSNP99.60to99.80,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -4.9627 <= x < -1.8251">
+##FILTER=<ID=VQSRTrancheSNP99.80to99.90,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -31.4709 <= x < -4.9627">
+##FILTER=<ID=VQSRTrancheSNP99.90to99.95,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -170.3725 <= x < -31.4709">
+##FILTER=<ID=VQSRTrancheSNP99.95to100.00+,Description="Truth sensitivity tranche level for SNP model at VQS Lod < -39645.8352">
+##FILTER=<ID=VQSRTrancheSNP99.95to100.00,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -39645.8352 <= x < -170.3725">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=MIN_DP,Number=1,Type=Integer,Description="Minimum DP observed within the GVCF block">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+##GATKCommandLine=<ID=ApplyRecalibration,Version=3.1-163-g4284d7a,Date="Fri Jun 06 05:42:47 EDT 2014",Epoch=1402047767783,CommandLineOptions="analysis_type=ApplyRecalibration input_file=[] showFullBamList=false read_buffer_size=null phone_home=AWS gatk_key=null tag=NA read_filter=[] intervals=[/seq/dax/macarthur_joint_calling/v2/scattered/temp_0001_of_1000/scattered.intervals] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=true num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=DYNAMIC_SEEK variant_index_parameter=-1 logging_level=INFO log_to_file=null help=false version=false input=[(RodBinding name=input source=/seq/dax/macarthur_joint_calling/v2/scattered/temp_0001_of_1000/genotypes.unfiltered.vcf.gz)] recal_file=(RodBinding name=recal_file source=/seq/dax/macarthur_joint_calling/v2/macarthur_joint_calling.indels.recal) tranches_file=/seq/dax/macarthur_joint_calling/v2/macarthur_joint_calling.indels.tranches out=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub ts_filter_level=95.0 lodCutoff=null ignore_filter=null excludeFiltered=false mode=INDEL filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##GATKCommandLine=<ID=SelectVariants,Version=3.3-33-g58cfab1,Date="Fri Nov 21 21:05:54 EST 2014",Epoch=1416621954228,CommandLineOptions="analysis_type=SelectVariants input_file=[] showFullBamList=false read_buffer_size=null phone_home=AWS gatk_key=null tag=NA read_filter=[] intervals=null excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false no_cmdline_in_header=false sites_only=false never_trim_vcf_format_field=false bcf=false bam_compression=null simplifyBAM=false disable_bam_indexing=false generate_md5=false num_threads=4 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=DYNAMIC_SEEK variant_index_parameter=-1 logging_level=INFO log_to_file=null help=false version=false variant=(RodBinding name=variant source=/humgen/gsa-firehose/ExAC_GATKV2.5/MacArthur_HC/v2/fullset/ExAC_HC.chrX.00.vcf.gz) discordance=(RodBinding name= source=UNBOUND) concordance=(RodBinding name= source=UNBOUND) out=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub sample_name=[] sample_expressions=null sample_file=[exac_panel.samples] exclude_sample_name=[] exclude_sample_file=[] select_expressions=[] excludeNonVariants=true excludeFiltered=false preserveAlleles=false restrictAllelesTo=ALL keepOriginalAC=false mendelianViolation=false mendelianViolationQualThreshold=0.0 select_random_fraction=0.0 remove_fraction_genotypes=0.0 selectTypeToInclude=[] keepIDs=null fullyDecode=false forceGenotypesDecode=false justRead=false maxIndelSize=2147483647 ALLOW_NONOVERLAPPING_COMMAND_LINE_SAMPLES=false filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##GATKCommandLine=<ID=VariantAnnotator,Version=3.2-2-gec30cee,Date="Mon Nov 24 21:39:16 EST 2014",Epoch=1416883156611,CommandLineOptions="analysis_type=VariantAnnotator input_file=[] showFullBamList=false read_buffer_size=null phone_home=AWS gatk_key=null tag=NA read_filter=[] intervals=[X:1-7763528] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=250 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=DYNAMIC_SEEK variant_index_parameter=-1 logging_level=INFO log_to_file=null help=false version=false variant=(RodBinding name=variant source=../filtered/ExAC_HC.chrX.00.filtered.vcf.gz) snpEffFile=(RodBinding name= source=UNBOUND) dbsnp=(RodBinding name= source=UNBOUND) comp=[] resource=[] out=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub annotation=[SexAlleleCounts] excludeAnnotation=[] group=[] expression={} useAllAnnotations=false list=false alwaysAppendDbsnpId=false MendelViolationGenotypeQualityThreshold=0.0 sampleMappingFile=samples_pop_sex.tsv filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##GATKCommandLine=<ID=VariantFiltration,Version=3.2-2-gec30cee,Date="Sun Nov 23 08:50:16 EST 2014",Epoch=1416750616237,CommandLineOptions="analysis_type=VariantFiltration input_file=[] showFullBamList=false read_buffer_size=null phone_home=AWS gatk_key=null tag=NA read_filter=[] intervals=[X:1-7763528] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 refactor_NDN_cigar_string=false fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false variant_index_type=DYNAMIC_SEEK variant_index_parameter=-1 logging_level=INFO log_to_file=null help=false version=false variant=(RodBinding name=variant source=../fullset/ExAC_HC.chrX.00.vcf.gz) mask=(RodBinding name= source=UNBOUND) out=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.gatk.engine.io.stubs.VariantContextWriterStub filterExpression=[VQSLOD > -2.632 && InbreedingCoeff >-0.8, InbreedingCoeff <= -0.8] filterName=[NewCut_Filter, InbreedingCoeff_Filter] genotypeFilterExpression=[] genotypeFilterName=[] clusterSize=3 clusterWindowSize=0 maskExtension=0 maskName=Mask filterNotInMask=false missingValuesInExpressionsShouldEvaluateAsFailing=false invalidatePreviousFilters=false filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
+##GVCFBlock=minGQ=0(inclusive),maxGQ=5(exclusive)
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_AFR,Number=A,Type=Integer,Description="African/African American Allele Counts">
+##INFO=<ID=AC_AMR,Number=A,Type=Integer,Description="American Allele Counts">
+##INFO=<ID=AC_Adj,Number=A,Type=Integer,Description="Adjusted Allele Counts">
+##INFO=<ID=AC_EAS,Number=A,Type=Integer,Description="East Asian Allele Counts">
+##INFO=<ID=AC_FIN,Number=A,Type=Integer,Description="Finnish Allele Counts">
+##INFO=<ID=AC_Hemi,Number=A,Type=Integer,Description="Adjusted Hemizygous Counts">
+##INFO=<ID=AC_Het,Number=A,Type=Integer,Description="Adjusted Heterozygous Counts">
+##INFO=<ID=AC_Hom,Number=A,Type=Integer,Description="Adjusted Homozygous Counts">
+##INFO=<ID=AC_NFE,Number=A,Type=Integer,Description="Non-Finnish European Allele Counts">
+##INFO=<ID=AC_OTH,Number=A,Type=Integer,Description="Other Allele Counts">
+##INFO=<ID=AC_SAS,Number=A,Type=Integer,Description="South Asian Allele Counts">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AN_AFR,Number=1,Type=Integer,Description="African/African American Chromosome Count">
+##INFO=<ID=AN_AMR,Number=1,Type=Integer,Description="American Chromosome Count">
+##INFO=<ID=AN_Adj,Number=1,Type=Integer,Description="Adjusted Chromosome Count">
+##INFO=<ID=AN_EAS,Number=1,Type=Integer,Description="East Asian Chromosome Count">
+##INFO=<ID=AN_FIN,Number=1,Type=Integer,Description="Finnish Chromosome Count">
+##INFO=<ID=AN_NFE,Number=1,Type=Integer,Description="Non-Finnish European Chromosome Count">
+##INFO=<ID=AN_OTH,Number=1,Type=Integer,Description="Other Chromosome Count">
+##INFO=<ID=AN_SAS,Number=1,Type=Integer,Description="South Asian Chromosome Count">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=CCC,Number=1,Type=Integer,Description="Number of called chromosomes">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP Membership">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=GQ_MEAN,Number=1,Type=Float,Description="Mean of all GQ values">
+##INFO=<ID=GQ_STDDEV,Number=1,Type=Float,Description="Standard deviation of all GQ values">
+##INFO=<ID=HWP,Number=1,Type=Float,Description="P value from test of Hardy Weinberg Equilibrium">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=Hemi_AFR,Number=A,Type=Integer,Description="African/African American Hemizygous Counts">
+##INFO=<ID=Hemi_AMR,Number=A,Type=Integer,Description="American Hemizygous Counts">
+##INFO=<ID=Hemi_EAS,Number=A,Type=Integer,Description="East Asian Hemizygous Counts">
+##INFO=<ID=Hemi_FIN,Number=A,Type=Integer,Description="Finnish Hemizygous Counts">
+##INFO=<ID=Hemi_NFE,Number=A,Type=Integer,Description="Non-Finnish European Hemizygous Counts">
+##INFO=<ID=Hemi_OTH,Number=A,Type=Integer,Description="Other Hemizygous Counts">
+##INFO=<ID=Hemi_SAS,Number=A,Type=Integer,Description="South Asian Hemizygous Counts">
+##INFO=<ID=Het_AFR,Number=A,Type=Integer,Description="African/African American Heterozygous Counts">
+##INFO=<ID=Het_AMR,Number=A,Type=Integer,Description="American Heterozygous Counts">
+##INFO=<ID=Het_EAS,Number=A,Type=Integer,Description="East Asian Heterozygous Counts">
+##INFO=<ID=Het_FIN,Number=A,Type=Integer,Description="Finnish Heterozygous Counts">
+##INFO=<ID=Het_NFE,Number=A,Type=Integer,Description="Non-Finnish European Heterozygous Counts">
+##INFO=<ID=Het_OTH,Number=A,Type=Integer,Description="Other Heterozygous Counts">
+##INFO=<ID=Het_SAS,Number=A,Type=Integer,Description="South Asian Heterozygous Counts">
+##INFO=<ID=Hom_AFR,Number=A,Type=Integer,Description="African/African American Homozygous Counts">
+##INFO=<ID=Hom_AMR,Number=A,Type=Integer,Description="American Homozygous Counts">
+##INFO=<ID=Hom_EAS,Number=A,Type=Integer,Description="East Asian Homozygous Counts">
+##INFO=<ID=Hom_FIN,Number=A,Type=Integer,Description="Finnish Homozygous Counts">
+##INFO=<ID=Hom_NFE,Number=A,Type=Integer,Description="Non-Finnish European Homozygous Counts">
+##INFO=<ID=Hom_OTH,Number=A,Type=Integer,Description="Other Homozygous Counts">
+##INFO=<ID=Hom_SAS,Number=A,Type=Integer,Description="South Asian Homozygous Counts">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=NCC,Number=1,Type=Integer,Description="Number of no-called samples">
+##INFO=<ID=NEGATIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the negative training set of bad variants">
+##INFO=<ID=POSITIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the positive training set of good variants">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##INFO=<ID=VQSLOD,Number=1,Type=Float,Description="Log odds ratio of being a true variant versus being false under the trained gaussian mixture model">
+##INFO=<ID=culprit,Number=1,Type=String,Description="The annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out">
+##contig=<ID=1,length=249250621>
+##contig=<ID=2,length=243199373>
+##contig=<ID=3,length=198022430>
+##contig=<ID=4,length=191154276>
+##contig=<ID=5,length=180915260>
+##contig=<ID=6,length=171115067>
+##contig=<ID=7,length=159138663>
+##contig=<ID=8,length=146364022>
+##contig=<ID=9,length=141213431>
+##contig=<ID=10,length=135534747>
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=133851895>
+##contig=<ID=13,length=115169878>
+##contig=<ID=14,length=107349540>
+##contig=<ID=15,length=102531392>
+##contig=<ID=16,length=90354753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=18,length=78077248>
+##contig=<ID=19,length=59128983>
+##contig=<ID=20,length=63025520>
+##contig=<ID=21,length=48129895>
+##contig=<ID=22,length=51304566>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##contig=<ID=MT,length=16569>
+##contig=<ID=GL000207.1,length=4262>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=GL000229.1,length=19913>
+##contig=<ID=GL000231.1,length=27386>
+##contig=<ID=GL000210.1,length=27682>
+##contig=<ID=GL000239.1,length=33824>
+##contig=<ID=GL000235.1,length=34474>
+##contig=<ID=GL000201.1,length=36148>
+##contig=<ID=GL000247.1,length=36422>
+##contig=<ID=GL000245.1,length=36651>
+##contig=<ID=GL000197.1,length=37175>
+##contig=<ID=GL000203.1,length=37498>
+##contig=<ID=GL000246.1,length=38154>
+##contig=<ID=GL000249.1,length=38502>
+##contig=<ID=GL000196.1,length=38914>
+##contig=<ID=GL000248.1,length=39786>
+##contig=<ID=GL000244.1,length=39929>
+##contig=<ID=GL000238.1,length=39939>
+##contig=<ID=GL000202.1,length=40103>
+##contig=<ID=GL000234.1,length=40531>
+##contig=<ID=GL000232.1,length=40652>
+##contig=<ID=GL000206.1,length=41001>
+##contig=<ID=GL000240.1,length=41933>
+##contig=<ID=GL000236.1,length=41934>
+##contig=<ID=GL000241.1,length=42152>
+##contig=<ID=GL000243.1,length=43341>
+##contig=<ID=GL000242.1,length=43523>
+##contig=<ID=GL000230.1,length=43691>
+##contig=<ID=GL000237.1,length=45867>
+##contig=<ID=GL000233.1,length=45941>
+##contig=<ID=GL000204.1,length=81310>
+##contig=<ID=GL000198.1,length=90085>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=GL000191.1,length=106433>
+##contig=<ID=GL000227.1,length=128374>
+##contig=<ID=GL000228.1,length=129120>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=GL000209.1,length=159169>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000211.1,length=166566>
+##contig=<ID=GL000199.1,length=169874>
+##contig=<ID=GL000217.1,length=172149>
+##contig=<ID=GL000216.1,length=172294>
+##contig=<ID=GL000215.1,length=172545>
+##contig=<ID=GL000205.1,length=174588>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000223.1,length=180455>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=GL000212.1,length=186858>
+##contig=<ID=GL000222.1,length=186861>
+##contig=<ID=GL000200.1,length=187035>
+##contig=<ID=GL000193.1,length=189789>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=GL000192.1,length=547496>
+##contig=<ID=NC_007605,length=171823>
+##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
+##source=SelectVariants
+##INFO=<ID=DP_HIST,Number=A,Type=String,Description="Histogram for DP; Mids: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=GQ_HIST,Number=A,Type=String,Description="Histogram for GQ; Mids: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##VEP=v77 cache=/humgen/atgu1/fs03/konradk/vep/tin//homo_sapiens/77_GRCh37 db=.
+##LoF_info=Info used for LoF annotation
+##LoF_flags=Possible warning flags for LoF
+##LoF_filter=Reason for LoF not being HC
+##LoF=Loss-of-function annotation (HC = High Confidence; LC = Low Confidence)
+##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence type as predicted by VEP. Format: Allele|Gene|Feature|Feature_type|Consequence|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|ALLELE_NUM|DISTANCE|STRAND|SYMBOL|SYMBOL_SOURCE|HGNC_ID|BIOTYPE|CANONICAL|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|SIFT|PolyPhen|EXON|INTRON|DOMAINS|HGVSc|HGVSp|GMAF|AFR_MAF|AMR_MAF|ASN_MAF|EUR_MAF|AA_MAF|EA_MAF|CLIN_SIG|SOMATIC|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|LoF_info|LoF_flags|LoF_filter|LoF">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	13372	.	G	C	608.91	PASS	AC=3;AC_AFR=0;AC_AMR=0;AC_Adj=2;AC_EAS=0;AC_FIN=0;AC_Het=0;AC_Hom=1;AC_NFE=0;AC_OTH=0;AC_SAS=2;AF=6.998e-05;AN=42870;AN_AFR=770;AN_AMR=134;AN_Adj=8432;AN_EAS=254;AN_FIN=16;AN_NFE=2116;AN_OTH=90;AN_SAS=5052;BaseQRankSum=0.727;ClippingRankSum=1.15;DP=139843;FS=0.000;GQ_MEAN=12.48;GQ_STDDEV=15.18;Het_AFR=0;Het_AMR=0;Het_EAS=0;Het_FIN=0;Het_NFE=0;Het_OTH=0;Het_SAS=0;Hom_AFR=0;Hom_AMR=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_SAS=1;InbreedingCoeff=-0.0844;MQ=35.72;MQ0=0;MQRankSum=0.727;NCC=60853;QD=23.42;ReadPosRankSum=0.727;VQSLOD=-1.687e+00;culprit=MQ;DP_HIST=14728|2455|2120|518|121|499|534|314|111|21|10|2|2|0|0|0|0|0|0|0,1|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST=1012|14971|172|100|3161|259|127|30|8|9|5|16|1162|274|59|45|17|2|3|3,0|0|0|0|0|1|0|0|0|0|0|0|0|1|0|0|0|0|0|0;CSQ=C|ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|620||||||1||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.620G>C|||||||||||||||||||,C|ENSG00000223972|ENST00000450305|Transcript|splice_region_variant&non_coding_transcript_exon_variant&non_coding_transcript_variant|412||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||5/6|||ENST00000450305.2:n.412G>C|||||||||||||||||||,C|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|613||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.613G>C|||||||||||||||||||,C|ENSG00000223972|ENST00000518655|Transcript|intron_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||2/3||ENST00000518655.2:n.482-31G>C|||||||||||||||||||,C||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||1||||||regulatory_region|||||||||||||||||||||||||||||||
+1	13380	.	C	G	7829.15	VQSRTrancheSNP99.60to99.80	AC=41;AC_AFR=22;AC_AMR=1;AC_Adj=23;AC_EAS=0;AC_FIN=0;AC_Het=23;AC_Hom=0;AC_NFE=0;AC_OTH=0;AC_SAS=0;AF=1.209e-03;AN=33902;AN_AFR=578;AN_AMR=104;AN_Adj=6922;AN_EAS=192;AN_FIN=8;AN_NFE=1684;AN_OTH=74;AN_SAS=4282;BaseQRankSum=0.018;ClippingRankSum=0.264;DP=106203;FS=4.314;GQ_MEAN=12.26;GQ_STDDEV=20.80;Het_AFR=22;Het_AMR=1;Het_EAS=0;Het_FIN=0;Het_NFE=0;Het_OTH=0;Het_SAS=0;Hom_AFR=0;Hom_AMR=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_SAS=0;InbreedingCoeff=-0.0794;MQ=31.93;MQ0=0;MQRankSum=0.00;NCC=67643;QD=8.10;ReadPosRankSum=-1.580e-01;VQSLOD=-3.041e+00;culprit=MQ;DP_HIST=11485|1978|1863|671|104|288|337|152|58|11|2|2|0|0|0|0|0|0|0|0,3|11|7|6|5|2|1|1|0|0|0|1|0|0|0|0|0|0|0|0;GQ_HIST=1048|11415|159|57|2884|298|140|17|3|5|1|4|570|210|55|45|16|3|4|17,0|2|1|0|2|0|0|0|0|4|0|4|2|0|1|1|2|1|1|16;CSQ=G|ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|628||||||1||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.628C>G|||||||||||||||||||,G|ENSG00000223972|ENST00000450305|Transcript|splice_region_variant&intron_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||5/5||ENST00000450305.2:n.414+6C>G|||||||||||||||||||,G|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|621||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.621C>G|||||||||||||||||||,G|ENSG00000223972|ENST00000518655|Transcript|intron_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||2/3||ENST00000518655.2:n.482-23C>G|||||||||||||||||||,G||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||1||||||regulatory_region|||||||||||||||||||||||||||||||
+1	13382	.	C	G	320.40	VQSRTrancheSNP99.60to99.80	AC=3;AC_AFR=0;AC_AMR=0;AC_Adj=1;AC_EAS=0;AC_FIN=0;AC_Het=1;AC_Hom=0;AC_NFE=0;AC_OTH=0;AC_SAS=1;AF=1.079e-04;AN=27810;AN_AFR=460;AN_AMR=82;AN_Adj=5728;AN_EAS=148;AN_FIN=4;AN_NFE=1400;AN_OTH=60;AN_SAS=3574;BaseQRankSum=-8.880e-01;ClippingRankSum=0.493;DP=86138;FS=0.000;GQ_MEAN=11.35;GQ_STDDEV=12.58;Het_AFR=0;Het_AMR=0;Het_EAS=0;Het_FIN=0;Het_NFE=0;Het_OTH=0;Het_SAS=1;Hom_AFR=0;Hom_AMR=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_SAS=0;InbreedingCoeff=-0.0832;MQ=34.49;MQ0=0;MQRankSum=-6.910e-01;NCC=72140;QD=20.03;ReadPosRankSum=-2.073e+00;VQSLOD=-4.106e+00;culprit=MQ;DP_HIST=9135|1821|1658|665|130|135|199|110|41|8|2|1|0|0|0|0|0|0|0|0,1|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST=1432|8682|140|118|2625|254|121|17|3|1|10|24|364|94|9|11|0|0|0|0,0|1|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0;CSQ=G|ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|630||||||1||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.630C>G|||||||||||||||||||,G|ENSG00000223972|ENST00000450305|Transcript|splice_region_variant&intron_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||5/5||ENST00000450305.2:n.414+8C>G|||||||||||||||||||,G|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|623||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.623C>G|||||||||||||||||||,G|ENSG00000223972|ENST00000518655|Transcript|intron_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||2/3||ENST00000518655.2:n.482-21C>G|||||||||||||||||||,G||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||1||||||regulatory_region|||||||||||||||||||||||||||||||
+1	13402	.	G	C	89.66	VQSRTrancheSNP99.60to99.80	AC=2;AC_AFR=0;AC_AMR=0;AC_Adj=0;AC_EAS=0;AC_FIN=0;AC_Het=0;AC_Hom=0;AC_NFE=0;AC_OTH=0;AC_SAS=0;AF=1.078e-04;AN=18552;AN_AFR=154;AN_AMR=20;AN_Adj=1476;AN_EAS=64;AN_FIN=0;AN_NFE=320;AN_OTH=20;AN_SAS=898;DP=38807;FS=0.000;GQ_MEAN=8.99;GQ_STDDEV=9.11;Het_AFR=0;Het_AMR=0;Het_EAS=0;Het_FIN=0;Het_NFE=0;Het_OTH=0;Het_SAS=0;Hom_AFR=0;Hom_AMR=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_SAS=0;InbreedingCoeff=-0.0874;MQ=25.88;MQ0=0;NCC=78915;QD=14.94;VQSLOD=-3.988e+00;culprit=MQ;DP_HIST=6706|1806|612|115|25|11|1|0|0|0|0|0|0|0|0|0|0|0|0|0,0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST=2262|4954|430|254|1039|135|105|45|11|11|3|0|23|3|1|0|0|0|0|0,0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;CSQ=C|ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|650||||||1||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.650G>C|||||||||||||||||||,C|ENSG00000223972|ENST00000450305|Transcript|intron_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||5/5||ENST00000450305.2:n.414+28G>C|||||||||||||||||||,C|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|643||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.643G>C|||||||||||||||||||,C|ENSG00000223972|ENST00000518655|Transcript|splice_acceptor_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||2/3||ENST00000518655.2:n.482-1G>C|||||||||||||||||||,C||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||1||||||regulatory_region|||||||||||||||||||||||||||||||
+1	13404	.	G	A,T	136.58	VQSRTrancheSNP99.60to99.80	AC=2,1;AC_AFR=0,0;AC_AMR=0,0;AC_Adj=0,1;AC_EAS=0,0;AC_FIN=0,0;AC_Het=0,1,0;AC_Hom=0,0;AC_NFE=0,0;AC_OTH=0,0;AC_SAS=0,1;AF=1.078e-04,5.391e-05;AN=18548;AN_AFR=142;AN_AMR=20;AN_Adj=1384;AN_EAS=62;AN_FIN=0;AN_NFE=300;AN_OTH=18;AN_SAS=842;BaseQRankSum=-2.780e-01;ClippingRankSum=0.896;DP=38414;FS=0.000;GQ_MEAN=8.90;GQ_STDDEV=9.04;Het_AFR=0,0,0;Het_AMR=0,0,0;Het_EAS=0,0,0;Het_FIN=0,0,0;Het_NFE=0,0,0;Het_OTH=0,0,0;Het_SAS=0,1,0;Hom_AFR=0,0;Hom_AMR=0,0;Hom_EAS=0,0;Hom_FIN=0,0;Hom_NFE=0,0;Hom_OTH=0,0;Hom_SAS=0,0;InbreedingCoeff=0.0831;MQ=22.58;MQ0=0;MQRankSum=-2.228e+00;NCC=78906;QD=8.54;ReadPosRankSum=0.278;VQSLOD=-2.933e+00;culprit=MQ;DP_HIST=6736|1815|573|115|24|11|0|0|0|0|0|0|0|0|0|0|0|0|0|0,0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0,0|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST=2258|5003|440|269|968|135|104|44|11|12|3|0|23|3|1|0|0|0|0|0,0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0,0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0;CSQ=A|ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|652||||||1||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.652G>A|||||||||||||||||||,T|ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|652||||||2||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.652G>T|||||||||||||||||||,A|ENSG00000223972|ENST00000450305|Transcript|intron_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||5/5||ENST00000450305.2:n.414+30G>A|||||||||||||||||||,T|ENSG00000223972|ENST00000450305|Transcript|intron_variant&non_coding_transcript_variant|||||||2||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||5/5||ENST00000450305.2:n.414+30G>T|||||||||||||||||||,A|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|645||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.645G>A|||||||||||||||||||,T|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|645||||||2||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.645G>T|||||||||||||||||||,A|ENSG00000223972|ENST00000518655|Transcript|splice_region_variant&non_coding_transcript_exon_variant&non_coding_transcript_variant|483||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/4|||ENST00000518655.2:n.483G>A|||||||||||||||||||,T|ENSG00000223972|ENST00000518655|Transcript|splice_region_variant&non_coding_transcript_exon_variant&non_coding_transcript_variant|483||||||2||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/4|||ENST00000518655.2:n.483G>T|||||||||||||||||||,A||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||1||||||regulatory_region|||||||||||||||||||||||||||||||,T||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||2||||||regulatory_region|||||||||||||||||||||||||||||||
+1	13417	.	C	CGAGA	258189.04	PASS	AC=1370;AC_AFR=5;AC_AMR=4;AC_Adj=214;AC_EAS=5;AC_FIN=0;AC_Het=204;AC_Hom=5;AC_NFE=50;AC_OTH=1;AC_SAS=149;AF=0.067;AN=20330;AN_AFR=150;AN_AMR=20;AN_Adj=1228;AN_EAS=66;AN_FIN=2;AN_NFE=250;AN_OTH=14;AN_SAS=726;BaseQRankSum=0.322;ClippingRankSum=0.322;DP=41441;FS=2.464;GQ_MEAN=17.84;GQ_STDDEV=54.08;Het_AFR=5;Het_AMR=4;Het_EAS=5;Het_FIN=0;Het_NFE=48;Het_OTH=1;Het_SAS=141;Hom_AFR=0;Hom_AMR=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=1;Hom_OTH=0;Hom_SAS=4;InbreedingCoeff=0.1962;MQ=23.67;MQ0=0;MQRankSum=0.550;NCC=77482;QD=17.64;ReadPosRankSum=-3.580e-01;VQSLOD=1.34;culprit=InbreedingCoeff;DP_HIST=7458|1998|549|119|34|7|0|0|0|0|0|0|0|0|0|0|0|0|0|0,297|494|158|41|8|2|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST=2551|5217|453|327|714|116|85|42|12|33|34|30|19|5|6|10|8|11|16|476,57|150|97|37|24|11|3|4|5|21|31|27|2|5|5|10|8|11|16|476;CSQ=GAGA|ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant&feature_elongation|665-666||||||1||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.665_666insGAGA|||||||||||||||||||,GAGA|ENSG00000223972|ENST00000450305|Transcript|intron_variant&non_coding_transcript_variant&feature_elongation|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||5/5||ENST00000450305.2:n.415-36_415-35insGAGA|||||||||||||||||||,GAGA|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant&feature_elongation|658-659||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.658_659insGAGA|||||||||||||||||||,GAGA|ENSG00000223972|ENST00000518655|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant&feature_elongation|496-497||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/4|||ENST00000518655.2:n.496_497insGAGA|||||||||||||||||||,GAGA||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||1||||||regulatory_region|||||||||||||||||||||||||||||||
+1	13418	.	G	A	510.63	AC_Adj0_Filter	AC=4;AC_AFR=0;AC_AMR=0;AC_Adj=0;AC_EAS=0;AC_FIN=0;AC_Het=0;AC_Hom=0;AC_NFE=0;AC_OTH=0;AC_SAS=0;AF=2.073e-04;AN=19292;AN_AFR=108;AN_AMR=8;AN_Adj=752;AN_EAS=52;AN_FIN=2;AN_NFE=138;AN_OTH=14;AN_SAS=430;BaseQRankSum=1.03;ClippingRankSum=-3.580e-01;DP=44639;FS=5.095;GQ_MEAN=7.43;GQ_STDDEV=8.72;Het_AFR=0;Het_AMR=0;Het_EAS=0;Het_FIN=0;Het_NFE=0;Het_OTH=0;Het_SAS=0;Hom_AFR=0;Hom_AMR=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_SAS=0;InbreedingCoeff=-0.1050;MQ=31.02;MQ0=0;MQRankSum=0.269;NCC=78090;QD=3.67;ReadPosRankSum=0.326;VQSLOD=-1.768e+00;culprit=MQ;DP_HIST=7216|1684|565|127|43|10|1|0|0|0|0|0|0|0|0|0|0|0|0|0,1|2|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST=3164|4988|325|244|667|102|76|34|6|11|3|1|23|0|1|0|1|0|0|0,0|1|1|0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0;CSQ=A|ENSG00000223972|ENST00000456328|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|666||||||1||1|DDX11L1|HGNC|37102|processed_transcript|YES||||||||3/3|||ENST00000456328.2:n.666G>A|||||||||||||||||||,A|ENSG00000223972|ENST00000450305|Transcript|intron_variant&non_coding_transcript_variant|||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene||||||||||5/5||ENST00000450305.2:n.415-35G>A|||||||||||||||||||,A|ENSG00000223972|ENST00000515242|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|659||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/3|||ENST00000515242.2:n.659G>A|||||||||||||||||||,A|ENSG00000223972|ENST00000518655|Transcript|non_coding_transcript_exon_variant&non_coding_transcript_variant|497||||||1||1|DDX11L1|HGNC|37102|transcribed_unprocessed_pseudogene|||||||||3/4|||ENST00000518655.2:n.497G>A|||||||||||||||||||,A||ENSR00000528767|RegulatoryFeature|regulatory_region_variant|||||||1||||||regulatory_region|||||||||||||||||||||||||||||||

--- a/vcf_parser/parser.py
+++ b/vcf_parser/parser.py
@@ -557,8 +557,11 @@ class VCFParser(object):
             variant['ALT'] = alternative
             variant['QUAL'] = variant_dict['QUAL']
             variant['FILTER'] = variant_dict['FILTER']
-            gt_format = variant_dict['FORMAT']
-            variant['FORMAT'] = gt_format
+            
+
+            if 'FORMAT' in variant_dict:
+                gt_format = variant_dict['FORMAT']
+                variant['FORMAT'] = gt_format
             
             
             for info in variant_dict['info_dict']:


### PR DESCRIPTION
When running vcf_parser on a VCF without FORMAT or samples, it breaks on multiallelic variants because no `'FORMAT'` key is found in `variant_dict`. This minor mod fixes that behaviour. 

ExAC is a good test case. 

`1       13404   .       G       A,T `

breaks with v1.2, but splits correctly with this patch.

To test: 

```
./scripts/vcf_parser examples/exac_head.vcf --split
```