### PR TITLE
Handle `=` in INFO fields

### DIFF
--- a/tests/test_build_vep_dict.py
+++ b/tests/test_build_vep_dict.py
@@ -215,3 +215,31 @@ def test_multiple_deletions():
          'SYMBOL': 'NOC2L'
           }
       ]
+
+
+def test_equals_sign_in_vep_consequence():
+    """
+    Test that equals signs in vep CSQs (for example "p.=" parses correctly)
+
+    Fix from https://github.com/jamescasbon/PyVCF/issues/181
+    """
+    vep_headers = ["Allele", "Feature_type", "HGVSp", "Consequence", "SYMBOL"]
+    annotation = [
+        "G|Transcript|p.=|downstream_gene_variant|NOC2L",
+        ]
+
+    vep_dict = build_vep_annotation(
+        csq_info=annotation,
+        reference='C',
+        alternatives=['G'],
+        vep_columns=vep_headers
+        )
+
+    assert vep_dict['G'] == [
+        {'Allele': 'G',
+         'Consequence': 'downstream_gene_variant',
+         'Feature_type': 'Transcript',
+         'HGVSp': 'p.=',
+         'SYMBOL': 'NOC2L'
+         }
+      ]

--- a/vcf_parser/utils/build_info.py
+++ b/vcf_parser/utils/build_info.py
@@ -53,7 +53,8 @@ def build_info_dict(vcf_info):
     for info in vcf_info.split(';'):
         info = info.split('=')
         if len(info) > 1:
-            #If the INFO entry is like key=value, we store the value as a list
+            # If the INFO entry is like key=value, we store the value as a list
+            info[1] = '='.join(info[1:])
             info_dict[info[0]] = info[1].split(',')
         else:
             info_dict[info[0]] = []


### PR DESCRIPTION
Sometimes there can be an equals sign (`=`) in the vep consequence, for
example an HGVSp `p.=`. This fix makes sure that’s handled gracefully.

This is similar to https://github.com/jamescasbon/PyVCF/issues/181